### PR TITLE
Supply previous value through empty update

### DIFF
--- a/src/usePrevious.test.ts
+++ b/src/usePrevious.test.ts
@@ -71,4 +71,12 @@ describe('test react-hooks-use-previous', () => {
         expect(result.current.prevValue).toBe(77);
         expect(result.current.value).toBe(33);
     });
+
+    it('should not update on rerender if prop is unchanged', () => {
+        const { result, rerender } = renderHook(() => usePrevious('current', 'initial'));
+
+        rerender();
+
+        expect(result.current).not.toBe('current');
+    });
 });

--- a/src/usePrevious.ts
+++ b/src/usePrevious.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef } from 'react';
 
 /**
  * Predefined hook to store and retrieve the previous value of the given reference to a string.
@@ -75,11 +75,14 @@ export const usePreviousBooleanArray = (value: boolean[], initialPreviousValue: 
  * the watched property was not updated.
  */
 const usePrevious = <T>(value: T, initialPreviousValue: T) => {
-    const ref = useRef<T>(initialPreviousValue);
-    useEffect(() => {
-        ref.current = value;
-    }, [value]);
-    return ref.current;
+    const { current } = useRef({ target: value, value: initialPreviousValue });
+
+    if (current.target !== value) {
+        current.value = current.target;
+        current.target = value;
+    }
+
+    return current.value;
 };
 
 export default usePrevious;


### PR DESCRIPTION
## Short description

When the hook is called but the props have not been updated (perhaps the hook is used on a component with many updates) the previous value should not update either. Currently the previous value is supplied only on the first render, and the current value is supplied on subsequent renders.

Fixes #7 

## Type of change

Bug fix (non-breaking change which fixes an issue)
